### PR TITLE
typo fix

### DIFF
--- a/pages/Advanced Queries.md
+++ b/pages/Advanced Queries.md
@@ -1,4 +1,4 @@
-- The database that Logseq used is [[https://github.com/tonsky/datascript][Datascript]], which is an immutable in-memory database and [Datalog](https://en.wikipedia.org/wiki/Datalog) query engine in Clojure and ClojureScript.
+- The database that Logseq used is [Datascript](https://github.com/tonsky/datascript), which is an immutable in-memory database and [Datalog](https://en.wikipedia.org/wiki/Datalog) query engine in Clojure and ClojureScript.
 - Logseq's database schema:
   https://github.com/logseq/logseq/blob/master/src/main/frontend/db_schema.cljs
 - Please check _Learn Datalog Today_ [^1] and _Datomic query syntax_ [^2] first if you're not familiar with Datalog.


### PR DESCRIPTION
the original `[[https://github.com/tonsky/datascript][Datascript]]` would display in a wrong way.