### PR TITLE
Fix broken footnote link in Advanced Queries

### DIFF
--- a/pages/Advanced Queries.md
+++ b/pages/Advanced Queries.md
@@ -263,4 +263,4 @@
       #+END_SRC
 - **Resources**
     - [^1]: [Learn Datalog Today](http://www.learndatalogtoday.org/)  is an interactive tutorial designed to teach you the Datomic dialect of Datalog.
-    - [^2]: [[https://docs.datomic.com/query.html][Datomic query documentation]]
+    - [^2]: [Datomic query documentation](https://docs.datomic.com/query.html)


### PR DESCRIPTION
This PR simply fixes a broken markdown link in the resources section of the Advanced Queries page