### PR TITLE
Fix formatting/display issues with Embed Media page

### DIFF
--- a/pages/Embed Media - Audio, Photos, Videos.md
+++ b/pages/Embed Media - Audio, Photos, Videos.md
@@ -1,7 +1,8 @@
 - ## Audio
-	- Using [[Hiccup]], it is possible to embed audio to your page and play it back.
+  collapsed:: true
+	- Using [[Hiccup]] or HTML embedding, it's possible to embed audio to your page and play it back.
 		- [:audio {:controls true :src "https://www.kozco.com/tech/piano2-CoolEdit.mp3"}]
-	- ### Embedding an audio file
+	- ### Embedding an audio file on your PC (using [[Hiccup]])
 		- To preview audio saved on your computer, type or copy-paste the following Hiccup ClojureScript, replacing the source `src` in "quotation marks" with the filepath and file name:
 		  ```
 		  [:audio {:controls true :src "file:C://Users/USERNAME/Folder/audio.ogg"}]
@@ -9,39 +10,59 @@
 		  #+BEGIN_TIP
 		  Make sure to include the `file:` at the start and to use forward slashes `/`
 		  #+END_TIP
-	- ### Embedding audio from a URL
+	- ### Embedding an audio file on your PC (using "/Embed HTML")
+		- If you are familiar with HTML markup and [prefer using `<audio>` tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio), you can leverage Logseq's HTML embed feature to preview audio saved on your computer. To do so, type or copy-paste the following line, replacing the source `src` in "quotation marks" with the filepath and file name:
+		  ```
+		  @@html: <audio controls><source src="file:C://Users/USERNAME/Folder/audio.ogg" type="audio/ogg"></audio>@@"}]
+		  ``` 
+		  #+BEGIN_TIP
+		  Make sure to include the `file:` at the start and to use forward slashes `/`
+		  #+END_TIP
+	- ### Embedding audio from a URL (using [[Hiccup]])
 		- To preview audio stored online, type or copy-paste the following Hiccup ClojureScript, replacing the source `src` in "quotation marks" with the actual URL:
 		  ```
 		  [:audio {:controls true :src "https://www.website.com/audio-file.wav"}]
 		  ```
 			- Example: 
+			  [:audio {:controls true :src "https://www.kozco.com/tech/piano2-CoolEdit.mp3"}]
 			  ```
 			  [:audio {:controls true :src "https://www.kozco.com/tech/piano2-CoolEdit.mp3"}]
-			  ``` 
-			  [:audio {:controls true :src "https://www.kozco.com/tech/piano2-CoolEdit.mp3"}]
+			  ```
+	- ### Embedding audio from a URL (using "/Embed HTML")
+		- If you are familiar with HTML markup and [prefer using `<audio>` tags](https://www.w3schools.com/html/html5_audio.asp), you can leverage Logseq's HTML embed feature to preview audio stored online. To do so, type or copy-paste the following line, replacing the source `src` in "quotation marks" with the actual URL:
+		  ```
+		  @@html: <audio controls><source src="https://www.website.com/audio-file.wav" type="audio/wav"></audio>@@
+		  ```
+			- Example: 
+			  @@html: <audio controls><source src="https://www.kozco.com/tech/piano2-CoolEdit.mp3" type="audio/mpeg"></audio>@@
+			  ```
+			  @@html: <audio controls><source src="https://www.kozco.com/tech/piano2-CoolEdit.mp3" type="audio/mpeg"></audio>@@
+			  ```
 - ## Photos, Images, GIFs
 	- To embed images, you can either:
 		- Copy-paste them into Logseq (which will duplicate the file into your Logseq's graph's folder in the `Assets` on your PC), OR
 		- Point the photos to a particular path on your computer storage or online storage.
 	- ### Embedding Images
-		- To preview an image saved on your computer in Logseq, type or copy-paste the following, replacing the filepath in (parenthesis) with the appropriate one: 
-		  ```Markdown
-		  ![optional: add a name](C://Users/USERNAME/Folder/image.gif)
-		  `` 
+		- To preview an image saved on your computer, type or copy-paste the following, replacing the filepath in (parenthesis) with the appropriate one:
+		  `![optional: add a name](C://Users/USERNAME/Folder/image.gif)`
+		  
 		  #+BEGIN_TIP
 		  Make sure to include the `!` at the start.
 		  #+END_TIP
-	- #+BEGIN_TIP
-	  You can specify the image size using 
-	  `{:height --, :width --}`
-	    ```
-	    ![label](image.gif){:height 418, :width 699}
-	    ```
-	  #+END_TIP
-	- ### Embedding images from a URL
-		- To preview am image from the internet, copy its link (with the file name and filepath) and paste it into Logseq. The image should automatically appear when you hit Enter.
-			- For example: `https://logseq.github.io/screenshots/1.png` 
-			  https://logseq.github.io/screenshots/1.png
+		  
+		  #+BEGIN_TIP
+		  	  You can specify the image size using `{:height --, :width --}` → Example:  `![label](image.gif){:height 418, :width 699}`
+		   #+END_TIP
+		- ### Embedding images from a URL
+			- To preview am image from the internet, copy its link (with the file name and filepath) and paste it into Logseq. The image should automatically appear when you hit Enter.
+				- For example:
+				- ![](https://logseq.github.io/screenshots/1.png){:height 469, :width 819}
+				  ```
+				  https://logseq.github.io/screenshots/1.png
+				  ```
+				  #+BEGIN_TIP
+				  	  You can specify the image size by formatting the image link as such: `![](https://logseq.github.io/screenshots/1.png){:height 469, :width 819}`
+				   #+END_TIP
 - ## Videos
 	- Using [[Hiccup]] and certain slash commands, it is possible to embed video to your page and play it back.
 	- ### Embedding a video file
@@ -52,33 +73,34 @@
 		  #+BEGIN_TIP
 		  Make sure to include the `file:` at the start and to use forward slashes
 		  #+END_TIP
-	- ### Embedding a videos from a URL
-		- To preview videos stored online, type or copy-paste the following Hiccup ClojureScript, replacing the source `src` in "quotation marks" with the actual URL:
-		  ```
-		  [:video {:controls true :src "https://www.website.com/video-file.webm"}]
-		  ```
+		- ### Embedding a videos from a URL
+			- To preview videos stored online, type or copy-paste the following Hiccup ClojureScript, replacing the source `src` in "quotation marks" with the actual URL:
+			  ```
+			  [:video {:controls true :src "https://www.website.com/video-file.webm"}]
+			  ```
 			- Example: 
-			  ```
-			  [:video {:controls true :src "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"}]
-			  ```
-			  [:video {:controls true :src "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"}]
-	- ### Embedding videos from YouTube
-	  collapsed:: true
-		- Type the slash `/` command and type `Embed YouTube Video`
-		- Select the command and paste the URL inside the `{{youtube }}` command
-			- Example: 
-			  ```
-			  {{youtube https://www.youtube.com/watch?v=SUOdfa3MucE}}
-			  ```
-			  {{youtube https://www.youtube.com/watch?v=SUOdfa3MucE}}
-		- To add timestamps, play the video, pause, create a new line. Type the slash `/` command and type `Embed YouTube timestamp`
-			- See the timestamps embed in action here (skip to 0:42 seconds): 
-			  <div style="position: relative; padding-bottom: 80.35714285714286%; height: 0;"><iframe src="https://www.loom.com/embed/995d6755b29c48c6b610646736aa5049" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
-	- ### Embedding videos from Vimeo
-		- Type the slash `/` command and type `Embed Vimeo Video`
-		- Select the command and paste the URL inside the `{{vimeo }}` command.
-			- Example: {{}}
-			  ```
-			  {{vimeo https://player.vimeo.com/video/535982936}}
-			  ```
-			  {{vimeo https://player.vimeo.com/video/535982936}}
+			  
+			   [:video {:controls true :src "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"}]
+			   ```
+			   [:video {:controls true :src "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"}]
+			   ```
+		- ### Embedding videos from YouTube
+			- Type the slash `/` command and type `Embed YouTube Video`
+			- Select the command and paste the URL inside the `{{youtube }}` command
+				- Example: 
+				   ```
+				   {{youtube https://www.youtube.com/watch?v=SUOdfa3MucE}}
+				   ```
+				   {{youtube https://www.youtube.com/watch?v=SUOdfa3MucE}}
+			- To add timestamps, play the video, pause, create a new line. Type the slash `/` command and type `Embed YouTube timestamp`
+				- Here is an example (click on the timestamp to jump to this position in the video): {{youtube-timestamp 369}}
+				- See the timestamps embed in action here (skip to 0:42 seconds): 
+				   <div style="position: relative; padding-bottom: 80.35714285714286%; height: 0;"><iframe src="https://www.loom.com/embed/995d6755b29c48c6b610646736aa5049" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
+		- ### Embedding videos from Vimeo
+			- Type the slash `/` command and type `Embed Vimeo video`
+			- Select the command and paste the URL inside the `{{vimeo }}` command.
+				- Example:
+				   {{vimeo https://player.vimeo.com/video/535982936}}
+				   ```
+				   {{vimeo https://player.vimeo.com/video/535982936}}
+				   ```


### PR DESCRIPTION
I've fixed the formatting issues that started at "Embedding Images" because of the tooltip. I also added some sections on embedding audio using the HTML embed command (@@html @@) and made some minor revisions.