### PR TITLE
Add icon to special properties doc

### DIFF
--- a/pages/term.properties.md
+++ b/pages/term.properties.md
@@ -98,3 +98,4 @@ click:: click me to edit
 	- `query-properties` (N) stores a user's custom properties to be shown for a query table.
 	- `filters` (N, object with booleans) store selected filters for linked references on page-level.
 	- `public` (boolean) defines whether a page should be included in an export.
+	- `icon` (1) define icon identifier for a page.


### PR DESCRIPTION
Adding an icon to identify a page is a common requirement. It would be nice for new users to have explicit instructions in the documentation. Currently icon as a special property is not mentioned in the documentation. I've add it to  **Special Properties** in `term/properties`.