### PR TITLE
fix(docs): Update DB scheme link

### DIFF
--- a/pages/Advanced Queries.md
+++ b/pages/Advanced Queries.md
@@ -3,7 +3,7 @@
     - [Learn Datalog Today](http://www.learndatalogtoday.org/) is a great first reference if you're not familiar with Datalog.
     - [Datomic query documentation](https://docs.datomic.com/query.html) - Thorough reference for datomic dialect of Datalog. Explains most datalog concepts well.
     - [Datascript's intro docs](https://github.com/tonsky/datascript/wiki/Getting-started)
-    - [Logseq's database schema](https://github.com/logseq/logseq/blob/master/src/main/frontend/db_schema.cljs)
+    - [Logseq's database schema](https://github.com/logseq/logseq/blob/master/deps/graph-parser/src/logseq/graph_parser/db/schema.cljs)
 - The query format is something like this:
   created_at:: 1609244764756
   updated-at:: 1609246099894


### PR DESCRIPTION
Recently a new graph parser was refactored which resulted in the location of the DB schema changing and rendering the existing link "dead". 

This PR addresses the issue by updating the link to the new location of the schema