### PR TITLE
Add link to plugins doc

### DIFF
--- a/pages/Plugins 01.md
+++ b/pages/Plugins 01.md
@@ -56,4 +56,4 @@
 	- Ask questions and discuss on Discord: https://discord.com/channels/725182569297215569/752845167030960141
 	- The plugin architecture:
 	  https://whimsical.com/logseq-plugins-draft-wip-B2iSbFBuWx1S4E4CkJed9y
-	- Read the Plugin API documentation: TODO
+	- Read the Plugin API documentation: https://plugins-doc.logseq.com/


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/66485719/212426996-355dfb30-f03b-4b84-98e8-11df61359613.png)

this file hasn't been updated in over a year so I'm assuming the documentation website is new