### PR TITLE
Add some clarification to What is indentation...

### DIFF
--- a/pages/What is indentation and why does it matter%3F.md
+++ b/pages/What is indentation and why does it matter%3F.md
@@ -8,9 +8,10 @@ title:: What is indentation and why does it matter?
 	- Block **B** is a _child_ of **A** and it's in the same _branch_ as blocks **C** and **D**.
 	- Block **C** is a _child_ of **A** and the _parent_ of **D**.
 - Why is this important? As we've discussed in the previous lessons, Logseq is a networked note-taking tool that works with links. We also discussed that Logseq has no hierarchy, which is actually nuanced. As you've probably deduced by now, hierarchy in Logseq happens at the block level.
-- By associating blocks, you create a branch that you can navigate. Let's turn the example above into links and navigate to the linked references of block **D,** which we'll name _Child **D**_:
+- By indenting blocks, you create a branch that you can navigate. Let's turn the example above into links and navigate to the _**Linked references**_ section of the page of _Child **D,**_ created for block **D**:
 	- ![child-d-path.png](../assets/child-d-path_1641572255030_0.png)
-- By going to the page of _Child **D**_, we can see this hierarchy it's in: first up is _Parent and child **C**_ and then _Parent **A**_.
+- By going to the page of _Child **D**_, we can see this hierarchy as it's composed on this documentation page: first up is _Parent and child **C**_ and then _Parent **A**_.
 - By clicking on one of the parents, the whole branch becomes visible:
 	- ![child-d-branch.png](../assets/child-d-branch_1641572326932_0.png)
+- Click again on one of the parents, and you will end up on that parent's page, again showing the composed hierarchy in the _**Linked Reference**_ section.
 - That's the basics of indentation! It's not much more complex than this, but it opens up a world of possibilities.


### PR DESCRIPTION
Please regard this PR as a suggestion...
I found this a _very_ hard page to grasp!

At first, I was expecting that after clicking on a parent in the hierarchy a second time, I would find a block with the links to children, and possibly indented links to grandchildren. But there weren't any blocks on these parent pages!

It took me a while to realize that the branch as created on the documentation page is _just one way_ to look at the relations between the separate notes.

It is totally possible to create another branch, that composes another way to look at the relations between those very same notes, e.g. in the context of a game between generations: [[a game of Contract Bridge]]
  Team 1
    [[Parent A]]
    [[Child D]]
  Team 2
    [[Child B]]
    [[Child and Parent C]]

In the Linked References section of all those 4 'person' notes, now the alternative hierarchy can be seen.

And that's the basics of indentation! ...

However, I just don't know if adding all this extra information will clutter the documentation page too much or not.