### PR TITLE
fix: spelling mistake in PDF highlights

### DIFF
--- a/pages/PDF highlights.md
+++ b/pages/PDF highlights.md
@@ -19,7 +19,7 @@ platforms:: [[Desktop]]
 		- ![CleanShot 2021-08-06 at 20.47.34.png](../assets/CleanShot_202021-08-06_20at_2020.47.34_1628254091556_0.png)
 	- Paste (`Cmd/Ctrl + v`) your highlighted reference to any block if you need.
 - **Do you have a dark theme for the PDF viewer?**
-	- Yes, there're **three** themes.
+	- Yes, there are **three** themes.
 - **Do you support outline?**
 	- Yes.
 	  ![CleanShot 2021-08-06 at 20.48.49.png](../assets/CleanShot_202021-08-06_20at_2020.48.49_1628254163734_0.png){:height 563, :width 325}


### PR DESCRIPTION
change there're to there are
