### PR TITLE
Italics syntax consistent with keyboard shortcut

### DIFF
--- a/pages/Markdown.md
+++ b/pages/Markdown.md
@@ -11,7 +11,7 @@ description:: Markdown is a popular markup language with many flavors. Our imple
 	  card-last-score:: 5
 		- knowledge base
 	- `**Bold**`   -> **Bold**
-	- `_Italics_ ` -> _Italics_
+	- `*Italics* ` -> *Italics*
 	- `~~Strikethrough~~` -> ~~Strikethrough~~
 	- `^^Highlight^^` -> ^^Highlight^^
 	- [:div [:code  "`Code`"]  "-> " [:code "Code"]]


### PR DESCRIPTION
Italics in Logseq can be produced by surrounding text with single asterisks or single underscores. `mod` + `i`, the keyboard shortcut for italic formatting, surrounds highlighted text with asterisks. This PR changes the syntax suggestion for italic text to `*Italics*`, using asterisks, to match the results of using the keyboard shortcut.

It's worth noting that `mod` + `b`, the keyboard shortcut for bold formatting, surrounds highlighted text with double asterisks, which is consistent with the suggested syntax in this docs page. (And surrounding text with double underscores also produces bold text, but isn't mentioned)