### PR TITLE
enhance: Add [[Undo and Redo]] ft documentation

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,7 +22,7 @@ jobs:
         run: touch www/.nojekyll
 
       - name: Deploy to gh-pages
-        uses: JamesIves/github-pages-deploy-action@4.1.9
+        uses: JamesIves/github-pages-deploy-action@4
         with:
           branch: gh-pages
           folder: www

--- a/pages/Changelog.md
+++ b/pages/Changelog.md
@@ -59,7 +59,7 @@
 		- Add hint class for the blank content block [#9072](https://github.com/logseq/logseq/pull/9072)
 		- Dynamic layout of the plugin UI items from the app toolbar [#8962](https://github.com/logseq/logseq/pull/8962)
 		- Add an apply button to multiple selects in query builder [#9025](https://github.com/logseq/logseq/pull/9025)
-		- Enhance undo redo handling [#9048](https://github.com/logseq/logseq/pull/9048)
+		- Enhance [[Undo and Redo]] handling [#9048](https://github.com/logseq/logseq/pull/9048)
 	- [[Fixed issues]]
 		- Bring back result count for built-in queries [#8954](https://github.com/logseq/logseq/pull/8954)
 		- Buggy selection highlights [#9074](https://github.com/logseq/logseq/pull/9074)
@@ -213,7 +213,7 @@
 			- Fix CodeMirror indenting shortcuts cause page routing [#8415](https://github.com/logseq/logseq/pull/8415)
 			- Fix: remove extra braces for some incorrect macro usages [#8381](https://github.com/logseq/logseq/pull/8381)
 			- Fix: searching in page defers while entering Chinese characters using a Pinyin IME [#8399](https://github.com/logseq/logseq/pull/8399)
-			- Fix incorrect undo/redo sequence of indent/outdent [#8228](https://github.com/logseq/logseq/pull/8228)
+			- Fix incorrect [[Undo and Redo]] sequence of indent/outdent [#8228](https://github.com/logseq/logseq/pull/8228)
 			- Fix validating of URLs in `video` block [#8164](https://github.com/logseq/logseq/pull/8164)
 		- [[Bad3r]]
 			- Fix docker web app failing to build [#8384](https://github.com/logseq/logseq/pull/8384)
@@ -249,7 +249,7 @@
 		- CodeMirror indenting shortcuts cause page routing [#8415](https://github.com/logseq/logseq/pull/8415)
 		- Page properties not being visible in the query table [#8336](https://github.com/logseq/logseq/pull/8336) [#8482](https://github.com/logseq/logseq/pull/8482) (Re-index required)
 		- Tables not widening in wide mode [#8375](https://github.com/logseq/logseq/pull/8375)
-		- Incorrect undo/redo sequence of indent/outdent [#8228](https://github.com/logseq/logseq/pull/8228)
+		- Incorrect [[Undo and Redo]] sequence of indent/outdent [#8228](https://github.com/logseq/logseq/pull/8228)
 		- Fix date-picker opening conditions [#8333](https://github.com/logseq/logseq/pull/8333)
 		- Stability of Logseq Sync, allow ignore checking certs, retrying upload [#8350](https://github.com/logseq/logseq/pull/8350) [#8504](https://github.com/logseq/logseq/pull/8504) [#8486](https://github.com/logseq/logseq/pull/8486)
 		- Missing PDF caused by incomplete linked file path from zotero [#7676](https://github.com/logseq/logseq/pull/7676)
@@ -286,7 +286,7 @@
 		- [[Sergio Miguéns]]
 			- Add a new option to show full blocks in references
 		- [[Phoenix Eliot]]
-			- Refine undo/redo button icons
+			- Refine [[Undo and Redo]] button icons
 			- Add note about auto-formatting in `dev-practices.md`
 		- [[sallto]]
 			- Remove non-clickable space between links in sidebar
@@ -314,7 +314,7 @@
 		- New query inputs for advanced query [#5674](https://github.com/logseq/logseq/pull/5674) [Document: Query Inputs](https://docs.logseq.com/#/page/advanced%20queries/block/query%20inputs)
 		- Add a new option `:ui/show-full-blocks?` to show full blocks in references [#8124](https://github.com/logseq/logseq/pull/8124)
 		- Prevent Ctrl+A from selecting the whole document [#7177](https://github.com/logseq/logseq/pull/7177)
-		- Refine undo/redo button icons [#8201](https://github.com/logseq/logseq/pull/8201)
+		- Refine [[Undo and Redo]] button icons [#8201](https://github.com/logseq/logseq/pull/8201)
 		- Make the weblink PDF filename to be human-readable for the annotations page [#8240](https://github.com/logseq/logseq/pull/8240)
 		- Plugin API: filter hooks of DB block changes for performance [#8234](https://github.com/logseq/logseq/pull/8234)
 		- No need to pass `isPageBlock` for api/insert_block API [#8176](https://github.com/logseq/logseq/pull/8176)
@@ -868,7 +868,7 @@
 			- Fix wrapped-by? utility function
 			- Press the Escape key to close action menu
 			- Fix moving cursor outside brackets when auto-complete
-			- Fix undo/redo while action menu is open
+			- Fix [[Undo and Redo]] while action menu is open
 		- [[Aryan Sawhney]]
 			- Fix incorrect feature request URL
 		- [[swk777]]
@@ -883,7 +883,7 @@
 		- Alias of a page in sidebar did not redirect to the original page [#6085](https://github.com/logseq/logseq/pull/6085)
 		- Fix roam export error caused by a typo [#6364](https://github.com/logseq/logseq/pull/6364)
 		- Fix moving cursor outside brackets when auto-complete [#6283](https://github.com/logseq/logseq/pull/6283)
-		- Fix undo/redo while the action menu is open [#6273](https://github.com/logseq/logseq/pull/6273)
+		- Fix [[Undo and Redo]] while the action menu is open [#6273](https://github.com/logseq/logseq/pull/6273)
 	- [[Enhancement]]
 		- Upgrade Electron to 19 [#6032](https://github.com/logseq/logseq/pull/6032)
 		- I18N: Polish translation [#6318](https://github.com/logseq/logseq/pull/6318), Improved Russian translation [#6324](https://github.com/logseq/logseq/pull/6324)

--- a/pages/Changelog_2020.org
+++ b/pages/Changelog_2020.org
@@ -283,7 +283,7 @@ The spent time for this block is ~18s~.
 **** 4. Fixed file not saved when switching to other page
 **** 5. Fixed git branches other than ~master~ not working
 *** [[Enhancement]]
-**** Better undo && redo
+**** Better [[Undo and Redo]]
 *** [[Features]]
 **** 1. Type ~s~ to switch between the file and the corresponding page (non editing mode)
 **** 2. Grammarly support even for single-line blocks
@@ -401,7 +401,7 @@ If you want to help translate Logseq, sign up here: https://crwd.in/logseq
 *** [[Fixed issues]]
 **** 1. Fixed issues related to roam json importer (still experiment)
 **** 2. Fixed not creating new journal page automatically
-**** 3. Better undo/redo behavior
+**** 3. Better [[Undo and Redo]] behavior
 **** 4. Support multiple notifications now (by haoji)
 **** 5. *All pages* support ~shift+click~ to open in right sidebar (by haoji)
 *** [[Features]]

--- a/pages/Refactoring_of_logseq.md
+++ b/pages/Refactoring_of_logseq.md
@@ -4,89 +4,89 @@ title: The Refactoring Of Logseq
 
 - We have been worked the refactoring of Logseq since about two months ago. Below I am going to talk bit about it.
 - Why does Logseq need refactoring?
-  
+
   Logseq was a side project for providing outliner features on org-mode and markdown files by @tiensonqin. Since it was released, many people like it a lot.  With the needs grew,  @Tiensonqin add many new features with happiness .  Compared to other outliner note-taking apps, Logseq has a lot of manipulation around files, characters, and bytes. It led to that codebase quickly grew into such situation -- many functions operate directly on raw string, as the design was easy to implement. With the increasing features, we encountered our problems.
-  
-  Most operations are around strings and their positions. When you create, update, delete a block, Logseq had to calculate the start-and-end positions, levels and updating the following blocks' positions and levels. In the beginning, we could make it correct by being careful. However, the software complexity grows incredibly fast. When we indent or outdent the blocks in batches,  drag a block tree, drop it into another position, or undo and redo the previous operations,  we still had to calculate the block's position and level, same as the children blocks' and the following blocks'. Even worse, we need to deal with Unicode characters, like CJK characters, which may occupy 3 or 4 bytes and hardly be calculated right at sometimes. Calculation based on raw strings was the main problem at that time.
-  
+
+  Most operations are around strings and their positions. When you create, update, delete a block, Logseq had to calculate the start-and-end positions, levels and updating the following blocks' positions and levels. In the beginning, we could make it correct by being careful. However, the software complexity grows incredibly fast. When we indent or outdent the blocks in batches,  drag a block tree, drop it into another position, or [[Undo and Redo]] the previous operations,  we still had to calculate the block's position and level, same as the children blocks' and the following blocks'. Even worse, we need to deal with Unicode characters, like CJK characters, which may occupy 3 or 4 bytes and hardly be calculated right at sometimes. Calculation based on raw strings was the main problem at that time.
+
   With the daily growth complexity, some other problems also need to solve, or these things will be another technical debt. A severe problem, I think, is that there are no apparent boundaries between modules, or say, the granularity of the modules is too coarse. It led that there was no mechanism to isolate errors when other modules failed. When a user filed a bug, it may lay in a wide range, which was very difficult to find out, and some minor bugs also might cause a dead error.
-  
-  The complexity and no boundaries pulled the developer's legs. To my surprise, I found that supporting Markdown & org-mode might already be our limit that Logseq can support. 
-  
+
+  The complexity and no boundaries pulled the developer's legs. To my surprise, I found that supporting Markdown & org-mode might already be our limit that Logseq can support.
+
   Now it's time to do something to improve, which I think they are reducing complexity, distinguishing the module boundary clearly, and improving stability and scalability.
-  
+
   Below is the architecture before refactoring.
-  
+
   ![Architecture-before-refactoring.png](https://user-images.githubusercontent.com/45989292/116767914-ab762e80-aa65-11eb-8f40-99d25425288b.png)
 - What have we done?
-  
+
   Let me post a new architecture first.
-  
+
   ![Arch-After-Refactoring.png](../assets/Arch-After-Refactoring_1619596960391_0.png)
     - Extract a Logseq Core
-      
+
       Logseq team is going to keep a small team for a long time. It requires us to focus on a minimal scope to achieve out goals----high quality, stable and scalability, rather than implementing all the features. The small scope is what we call Logseq core. For the other features, we will utilize the plugin system to satisfy.
-      
+
       The most critical component in Logseq Core is the outliner. Let's take some more time to talks about it.
         - Outliner
-          
+
           If taking the previous design, we'll continuously have to deal with the headache strings and bytes and hardly optimize it. So, we need to seek another solution. We should move all the string and byte calculations out of the outliner logic in the first step. So we had moved the logic of serialization and deserialization of a block into plugins. Doing this brings another significant benefit: we can easily implement multiple persistent storages such as markdown files, org-mode files, AsciiDoc files, or SQLite, etc., by just writing different serialize & deserialize adaptors. The outliner module, which is the main component of Logseq Core, only receives and sends meaningful structured data that have been deserialized or will be serialized. Then, we need to decide how to organize the relationship between blocks. Assuming that we have some blocks:
-          
-          ![logseq-tree.png](https://user-images.githubusercontent.com/45989292/116767915-ac0ec500-aa65-11eb-81fd-15cd9b104af2.png) 
-          
+
+          ![logseq-tree.png](https://user-images.githubusercontent.com/45989292/116767915-ac0ec500-aa65-11eb-81fd-15cd9b104af2.png)
+
           The relations in Logseq looks like a tree in the picture below (the picture below is from the Internet) :
-          
+
           ![tree.png](https://user-images.githubusercontent.com/45989292/116767932-b7fa8700-aa65-11eb-83b2-c223984c819f.png) [](/refactoring-of-logseq/tree.png)
-          
+
           At the very beginning, I proposed a data structure to organize the block relations. After a long discussion (about costs & benefits & whether it fit us and ...), other workmates confirmed its feasibility. Then it became the most fundamental part of outliner operation in Logseq until now, and it's straightforward.
-          
+
           Relations:
-          
+
           |    Node id   | parent_id | left_id |...|
           | ----------- | ----------- | ----------- |-----------|
           | 1      | nil       | nil |...|
           | 2   | 1        | 1 |...|
           | 7   | 1 | 2 |...|
-          
+
           Let's dive into the outliner operation. We briefly show how to make block CRUD here.
-          
+
           * Create a new block
-          
+
           We will create a block record when adding a block. We assume the block's ID is 13 and between 2 and 7.
-          
+
           Logseq should set 13's parent_id as 1, and left_id as 2, then update 7's left_id to 13.
-          
+
           * Update block's content
-          
+
           We only need to update the block record—no need to update relations.
-          
+
           * Delete a block
-          
+
           Assuming we want to delete block 7, we need to delete the block record and update 8's left as 2.
-          
+
           * Move a subtree
-          
+
           Assuming we want to move subtree (3,4, 5) to a position where is between 2, 7. We only need to update 3's parent_id as 1, 3's left_id as 2, then update 7's left_id as 3.
-          
+
           The other day, somebody told me that some of others use `children` and `order` (abbr: order-solution for convenience) rather than `parent_id` and `left_id`(abbr: left-solution for convenience) to process the relation of blocks, and I might think about it. (PS: Datascript can only save look-refs as `set` rather than `vector`.)
-          
+
           I thought that left-solution is still simpler and more efficient in our case. When inserting a block in the middle of sibling nodes, order-solution needs to update the whole following siblings' order number; And when moving a subtree as a child to another parent, order-solution needs to update the following order numbers on both sides. If a block has a large number of children, the calculation will be very impressive.
         - Concepts
-          
+
           Logseq has three main concepts, which are graph, page, and block. A page maps to a single file on the file system. After refactoring, page becomes one type of block. It brings some benefits.  It won't necessarily be related to a file or other thing inside storage. It becomes more abstract and general. It is just the root of a block tree. The whole graph is a big tree of blocks,  and the page is a normal node in it representing a specific collection of blocks. Moving a block or some blocks from a page into another page is a natural moving-subtree operation.
         - Hooks
-          
-          The outliner is very simple, so we should find a way to enhance the ability of Logseq to meet various demands. Hook is our final choice. Hooks can plug in the whole lifecycle of outliner operations. For example, we have provided a hook point for reading the block data when a new block inserts or block changes and a hook point to save block when it receives valid block data. These two hooks could provide the ability to connect arbitrary persistent storage,  which including but not limited to Markdown, Org-mode, SQLite, Elasticsearch, and so on.  Another example is, we have provided a hook that is invoked when the Logseq on load. The Logseq plugin authors can utilize the hook to design widgets, custom the themes, or whatever the user has been privileged. 
-          
+
+          The outliner is very simple, so we should find a way to enhance the ability of Logseq to meet various demands. Hook is our final choice. Hooks can plug in the whole lifecycle of outliner operations. For example, we have provided a hook point for reading the block data when a new block inserts or block changes and a hook point to save block when it receives valid block data. These two hooks could provide the ability to connect arbitrary persistent storage,  which including but not limited to Markdown, Org-mode, SQLite, Elasticsearch, and so on.  Another example is, we have provided a hook that is invoked when the Logseq on load. The Logseq plugin authors can utilize the hook to design widgets, custom the themes, or whatever the user has been privileged.
+
           The hook is a middle layer between outliner and plugins. There will be many hooks,  I hope they will make Logseq more powerful.
     - Build Logseq Plugin Core and Official Plugins
-      
-      I think Official Plugins and Developer Plugins almost have the same ability. Only under these two conditions, Logseq team might provide the plugin: 
-      
-       * The plugin might be related to user data security. 
+
+      I think Official Plugins and Developer Plugins almost have the same ability. Only under these two conditions, Logseq team might provide the plugin:
+
+       * The plugin might be related to user data security.
        * The plugin could provide a more complete user experience out of the box. For example, we provide the Markdown, org-mode storage plugin.
-      
+
       Logseq Plugin Core is an abstract layer for Developer Plugins. The related API details are also coming soon.
 - Conclusion
-  
+
   Logseq team is going to refocus on Logseq Core and nail the foundation. I hope we can build a reliable, flexible, and minimal core and bring us a new experience.  The outliner's implementation is side-effect-free and straightforward, and we'll add more tests to make it more robust; The plugin system will bring us more possibilities to meet our needs. We hope you like it.

--- a/pages/Undo and Redo.md
+++ b/pages/Undo and Redo.md
@@ -4,27 +4,26 @@ description:: Describes Undo and Redo behavior and modes.
 
 - ## Introduction
 	- The Logseq Undo and Redo feature allows users to revert or reapply changes made during their editing sessions. It aims to enhance the user experience by providing a convenient way to correct mistakes and explore alternative edits.
-	- Purpose and benefits include providing context for previous operations, supporting page-only mode, allowing unlimited Undo and Redo history, and restoring cursor state.
 - ## Usage
 	- Keyboard shortcuts:
 		- Undo: Press `mod` + `z` (`mod` is "Control" on Windows/Linux, "Command" on macOS).
 		- Redo: Press `mod` + `Shift` + `z`.
+	- Undo and Redo Modes
+		- The functionality offers two modes: `page only` and `global graph`.
+		- To switch between modes, open the commands palette with `mod` + `Shift` + `P` (`mod` is "Control" on Windows/Linux, "Command" on macOS), and select the `Toggle undo redo mode (global or page only)` option.
 	- Undo and Redo behavior in different scenarios:
-		- Text input: Undoing and redoing typed text. For example, typing 'text 1' and then undoing it will remove 'text 1' from the page, while redoing it will make 'text 1' reappear.
-		- Page navigation: Navigate to the corresponding pages on undo, including navigating back to the last page visited. For instance, after creating a new page and navigating to it, pressing undo will bring you back to the previous page.
-		- Page renaming: Preserving Undo and Redo actions for renamed pages and navigating to the page on undo. For example, renaming a page and then undoing the rename action will return to the original page name, while redoing it will apply the new name again.
-		- Working with blocks: Undoing and redoing block operations, such as creating, editing, indenting, and deleting blocks.
-		- Restoring the right sidebar: Restoring both the route and blocks in the right sidebar to provide context for any previous operations and reduce the risk of undoing something users haven't noticed.
-	- The Undo and Redo feature works seamlessly with other Logseq features, such as creating, renaming, and navigating pages.
+		- **Text input**: Undoing and redoing typed text.
+		- **Page navigation**: Navigate to the corresponding pages on undo, including navigating back to the last page visited.
+		- **Page renaming**: Preserving Undo and Redo actions for renamed pages and navigating to the page on undo.
+		- **Block operations**: Undoing and redoing block operations, such as creating, editing, indenting, and deleting blocks.
 - ## Functionality
-	- Restoring UI state: Restores the route and blocks in the right sidebar to provide context for any previous operations.
-	- Page-only mode: Supports page-only mode (mod+shift+p and search toggle Undo and Redo mode).
-	- Unlimited Undo and Redo history: Allows Undo and Redo history to grow without limitations.
-	- Cursor state restoration: Restores the cursor state after undoing or redoing an action.
-	- Interaction with other Logseq features: The Undo and Redo feature works seamlessly with other Logseq features, such as creating, renaming, and navigating pages.
+	- Restores the route and blocks in the right sidebar to provide context for any previous operations.
+	- Supports page-only mode.
+	- Allows Undo and Redo history to grow without limitations.
+	- Restores the cursor state after undoing or redoing an action.
+	- Works seamlessly with other Logseq features, such as creating, renaming, and navigating pages.
 - ## Limitations and Known Issues
-	- Support for flashcards: Currently, the Undo and Redo behavior for flashcards is unavailable.
-	- Support for editing in page/block preview: Currently, the Undo and Redo behavior for page/block preview is unavailable.
-	- Behavior when working with external files and syncing: The behavior of Undo and Redo when working with external files or syncing with external services may differ.
-	- Performance impact with extensive Undo and Redo history: A significant Undo and Redo history might impact performance, although this is not confirmed.
-	- Any other limitations or issues: Future updates might address the current limitations and improve the Undo and Redo functionality.
+	- Currently unavailable for flashcards and page/block preview.
+	- Undo and Redo behavior may differ when working with external editors or syncing, which may affect the availability or reliability of Undo and Redo actions.
+	- A significant Undo and Redo history might impact performance, although this is not confirmed.
+	- Future updates might address the current limitations and improve the Undo and Redo functionality.

--- a/pages/Undo and Redo.md
+++ b/pages/Undo and Redo.md
@@ -1,0 +1,30 @@
+type:: [[Feature]]
+platforms:: [[All Platforms]] except [[Publish Web]]
+description:: Describes Undo and Redo behavior and modes.
+
+- ## Introduction
+	- The Logseq Undo and Redo feature allows users to revert or reapply changes made during their editing sessions. It aims to enhance the user experience by providing a convenient way to correct mistakes and explore alternative edits.
+	- Purpose and benefits include providing context for previous operations, supporting page-only mode, allowing unlimited Undo and Redo history, and restoring cursor state.
+- ## Usage
+	- Keyboard shortcuts:
+		- Undo: Press `mod` + `z` (`mod` is "Control" on Windows/Linux, "Command" on macOS).
+		- Redo: Press `mod` + `Shift` + `z`.
+	- Undo and Redo behavior in different scenarios:
+		- Text input: Undoing and redoing typed text. For example, typing 'text 1' and then undoing it will remove 'text 1' from the page, while redoing it will make 'text 1' reappear.
+		- Page navigation: Navigate to the corresponding pages on undo, including navigating back to the last page visited. For instance, after creating a new page and navigating to it, pressing undo will bring you back to the previous page.
+		- Page renaming: Preserving Undo and Redo actions for renamed pages and navigating to the page on undo. For example, renaming a page and then undoing the rename action will return to the original page name, while redoing it will apply the new name again.
+		- Working with blocks: Undoing and redoing block operations, such as creating, editing, indenting, and deleting blocks.
+		- Restoring the right sidebar: Restoring both the route and blocks in the right sidebar to provide context for any previous operations and reduce the risk of undoing something users haven't noticed.
+	- The Undo and Redo feature works seamlessly with other Logseq features, such as creating, renaming, and navigating pages.
+- ## Functionality
+	- Restoring UI state: Restores the route and blocks in the right sidebar to provide context for any previous operations.
+	- Page-only mode: Supports page-only mode (mod+shift+p and search toggle Undo and Redo mode).
+	- Unlimited Undo and Redo history: Allows Undo and Redo history to grow without limitations.
+	- Cursor state restoration: Restores the cursor state after undoing or redoing an action.
+	- Interaction with other Logseq features: The Undo and Redo feature works seamlessly with other Logseq features, such as creating, renaming, and navigating pages.
+- ## Limitations and Known Issues
+	- Support for flashcards: Currently, the Undo and Redo behavior for flashcards is unavailable.
+	- Support for editing in page/block preview: Currently, the Undo and Redo behavior for page/block preview is unavailable.
+	- Behavior when working with external files and syncing: The behavior of Undo and Redo when working with external files or syncing with external services may differ.
+	- Performance impact with extensive Undo and Redo history: A significant Undo and Redo history might impact performance, although this is not confirmed.
+	- Any other limitations or issues: Future updates might address the current limitations and improve the Undo and Redo functionality.

--- a/pages/canary changelog.md
+++ b/pages/canary changelog.md
@@ -6,16 +6,16 @@ title: Canary Changelog
   Canary Version 0.0.1
   Desktop app download link:
   https://github.com/logseq/logseq/releases/tag/0.0.1
-  
+
   Logseq Canary is for early adopters and developers to test new features and APIs without affecting the stable working environment. It will be installed as a separate app besides the stable one.
-  
+
   #+BEGIN_WARNING
   To play it safe, we recommend using new content only with the canary app. If you want to try it with existing content, do remember to back up first in case of data loss or corruption.
   #+END_WARNING
 	- This is the first canary release, introducing the big refactoring of Logseq. The rationale behind the refactoring is detailed here [[The Refactoring Of Logseq]]. Overall, it makes the code simpler and more robust, fixes some long-standing issues along the way and paves the way for upcoming features.
 	- [[Enhancement]]
 		- A refactored core that is simpler and more robust.
-		- A much better undo/redo experience.
+		- A much better [[Undo and Redo]] experience.
 		- Better keyboard navigation:
 			- ![](https://user-images.githubusercontent.com/45989292/116767907-a44f2080-aa65-11eb-9cc3-e2ed34e4b6aa.gif)
 			- We've made most of above shortcuts customizable as well. If you don't like arrow keys, you can change it. Also for navigation keys in auto-completion, search, and more.

--- a/pages/changelog_06.md
+++ b/pages/changelog_06.md
@@ -85,7 +85,7 @@
 			    - b        (level 2)
 			       - c      (level 3)
 			          - d    (level 4)
-			  
+
 			  With the default value of level 2, `b` will be collapsed.
 			  If we set the level's value to 3, `b` will be opened and `c` will be collapsed.
 			  #+END_EXAMPLE
@@ -495,7 +495,7 @@
 		  <div style="position: relative; padding-bottom: 56.25%; height: 0;"><iframe src="https://www.loom.com/embed/39a34471c10f498bb5c37e898661b2d9" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
 		  [:hr]
 			- The desktop app can export all the public notes and logseq's Javascript and CSS files to a specified directory, then you can deploy it to GitHub pages, Vercel or your hosting service!
-			  
+
 			  Read more at [[Publishing (Desktop App Only)]]
 		- Initial support for [[Namespaces]], namespace can be used to avoid name conflicts, also, it can be used for building hierarchical relationships later.
 		  [[book/how to take dummy notes]] will create the parent page `book`.
@@ -528,7 +528,7 @@
 			  {:title "All todos"
 			   :query (todo todo later done)}
 			  #+END_EXAMPLE
-			  
+
 			  #+BEGIN_QUERY
 			  {:title "All todos"
 			   :query (and (todo todo later done doing now))}
@@ -666,7 +666,7 @@
 		- Don't jump to new journal when in editing mode
 		- And other fixes
 	- [[Enhancement]]
-		- Better Undo && Redo
+		- Better [[Undo and Redo]]
 		- Faster full-text search
 		- Add built-in pages such as TODO keywords and priorities
 - [[Feb 5th, 2021]]
@@ -706,9 +706,9 @@
 		- Fix footnotes not working
 		  For example:
 		  Here's a simple footnote,[^1] and here's a longer one.[^bignote]
-		  
+
 		  [^1]: This is the first footnote.
-		  
+
 		  [^bignote]: Here's one with multiple paragraphs and code.
 		- Fix both preferred workflow and preferred format settings not working
 		- Fix `/` commands list is empty
@@ -742,7 +742,7 @@
 		- main.js
 		-
 	- [[Enhancement]]
-		- 1. **Much stable Undo && Redo**
+		- 1. **Much stable [[Undo and Redo]]**
 		  `Notice`: It could be slow with page that has many blocks.
 		  There's a bug with block timestamps enabled, so we disabled it temporally.
 		- 2. `Ctrl+s` to save and push to GitHub

--- a/pages/one year in logseq.md
+++ b/pages/one year in logseq.md
@@ -4,14 +4,14 @@ title: One year in Logseq
 
 - **Hello, everyone!**
 - **A little about the team**
-	- **Michael** 
+	- **Michael**
 	  ![image.png](../assets/pages_one year in logseq_1616235681415_0.png){:height 560, :width 960}
 	- **Charlie**  ![image.png](../assets/pages_one year in logseq_1616235711538_0.png)
 	- **Zhiyuan**
 	  ![image.png](../assets/pages_one year in logseq_1616235763365_0.png)
 	- **Weihua**
 	  ![image.png](../assets/pages_one year in logseq_1616235785959_0.png)
-	- **Junyu** 
+	- **Junyu**
 	  ![CleanShot 2021-03-20 at 18.53.56@2x.png](../assets/pages_one year in logseq_1616237665640_0.png){:height 379, :width 279}
 	- I'm Tienson from Hangzhou, thanks to my wife we have a beautiful daughter.
 		- ![CleanShot 2021-03-20 at 18.15.54@2x.png](../assets/pages_one year in logseq_1616235368782_0.png){:height 557, :width 518}
@@ -52,7 +52,7 @@ title: One year in Logseq
 		- Publishing the whole web app to your own website
 - **The future**
 	- More stable and more performant
-	- Better undo/redo `#undotree`
+	- Better [[Undo and Redo]] `#undotree`
 	- End-to-End encryption storage
 	- Mobile apps
 	- Real-time collaboration


### PR DESCRIPTION
Demo page: https://dev.unsigned.sh/logseq-docs/#/page/undo%20and%20redo

related discussion on Discord:
https://discord.com/channels/725182569297215569/1096271273400746045/1099039820581445732


```
Bader — 13/04/2023 23:10
Undo/redo Docs 🔄
Bader — 13/04/2023 23:10
🧵
Bader — 13/04/2023 23:18
Currently, there is no dedicated page for undo/redo behavior. Should one be added? Do you have a preference for the title?

related PR:
https://github.com/logseq/logseq/pull/9048

There is the undo/redo of block indent as well:
https://github.com/logseq/logseq/pull/8228

I think there is another PR related to this change but I am not sure which one.
Bader — 13/04/2023 23:31
there is multiple old PRs related to improving and fixing undo/redo but I don't think they add any more information
Bader
 changed the channel name: 
Undo/redo Docs 🔄
 — 14/04/2023 00:04
Ramses — 14/04/2023 07:22
If you want to write it, I'd happily accept the pull request for the docs repo @Bader. Although I'd hope our engineers to write the technical docs 😬
cldwalker — 14/04/2023 09:52
9048 is the main one I was thinking of as it adds a new mode to undo/redo. A new feature page for it would be great. https://docs.logseq.com/#/page/copy%20and%20paste is a similar page for a general editing feature
cldwalker — 14/04/2023 10:04
Fwiw I asked Bader for help on these. Agreed it'd be nice if the team wrote them. Unfortunately I'm the sole engineer consistently writing them and we're moving fast. I don't mind asking for help as long as the contributions aren't more work than doing it myself
Ramses — 14/04/2023 10:46
Good to know, thanks for context! @Bader the page that Gabriel linked to is a good template. Maybe it's an idea to have a page with this template for easy reuse
And please ping me on Discord if you have a pull request for the docs. I don't check GitHub that often 😬
Bader — 14/04/2023 11:03
yeah I agree having a base template to follow is great. Mentally I usually always start with Overview, Usage, Functionality.
Here is the template I plan to use for undo/redo (subject to change)
## Undo and Redo

### Introduction
   - Overview of the undo and redo feature
   - Purpose and benefits

### Usage
   - Keyboard shortcuts
   - Undo and redo behavior in different scenarios
      - Text input
      - Page navigation
      - Page renaming
      - Block indenting
      - Restoring the right sidebar
   - Examples of using undo and redo in common scenarios

### Functionality
   - Restoring UI state
   - Page-only mode
   - Unlimited undo/redo history
   - Cursor state restoration
   - Interaction with other Logseq features?

### Limitations and Known Issues
   - Support for flashcards
   - Support for editing in page/block preview
   - Behavior when working with external files and syncing
   - Performance impact with extensive undo/redo history
   - Any other limitations or issues
 
Bader — 14/04/2023 12:41
Revision 2 with extra context:
## Logseq Undo and Redo Feature Documentation

### Introduction
   - The Logseq undo and redo feature allows users to revert or reapply changes made during their editing sessions. It aims to enhance the user experience by providing a convenient way to correct mistakes and explore alternative edits.
   - Purpose and benefits include providing context for previous operations, supporting page-only mode, allowing unlimited undo/redo history, and restoring cursor state.

### Usage
   - Keyboard shortcuts:
      - Undo: Press `modKey` + `z` (`modKey` is "Control" on Windows/Linux, "Command" on macOS).
      - Redo: Press `modKey` + `Shift` + `z`.
   - Undo and redo behavior in different scenarios:
      - Text input: Undoing and redoing typed text. For example, typing 'text 1' and then undoing it will remove 'text 1' from the page, while redoing it will make 'text 1' reappear.
      - Page navigation: Navigate to the corresponding pages on undo, including navigating back to the last page visited. For instance, after creating a new page and navigating to it, pressing undo will bring you back to the previous page.
      - Page renaming: Preserving undo/redo actions for renamed pages and navigating to the page on undo. For example, renaming a page and then undoing the rename action will return to the original page name, while redoing it will apply the new name again.
      - Working with blocks: Undoing and redoing block operations, such as creating, editing, indenting, and deleting blocks.
      - Restoring the right sidebar: Restoring both the route and blocks in the right sidebar to provide context for any previous operations and reduce the risk of undoing something users haven't noticed.
   - The undo and redo feature works seamlessly with other Logseq features, such as creating, renaming, and navigating pages.

### Functionality
   - Restoring UI state: Restores the route and blocks in the right sidebar to provide context for any previous operations.
   - Page-only mode: Supports page-only mode (mod+shift+p and search toggle undo redo mode).
   - Unlimited undo/redo history: Allows undo/redo history to grow without limitations.
   - Cursor state restoration: Restores the cursor state after undoing or redoing an action.
   - Interaction with other Logseq features: The undo and redo feature works seamlessly with other Logseq features, such as creating, renaming, and navigating pages.

### Limitations and Known Issues
   - Support for flashcards: Currently, the undo and redo behavior for flashcards is unavailable.
   - Support for editing in page/block preview: Currently, the undo and redo behavior for page/block preview is unavailable.
   - Behavior when working with external files and syncing: The behavior of undo and redo when working with external files or syncing with external services may differ.
   - Performance impact with extensive undo/redo history: A significant undo/redo history might impact performance, although this is not confirmed.
   - Any other limitations or issues: Future updates might address the current limitations and improve the undo and redo functionality.
 
cldwalker — Yesterday at 10:03
Looks promising. PR would be great
Bader — Yesterday at 10:06
sounds great. I just moved to a new apartment so I have been busy. I'll be able to push it before Monday. 
Btw this is kinda related 

https://github.com/logseq/logseq/pull/9181
GitHub
fix: cannot undo redo in codemirror editor by situ2001 · Pull Reque...
Background: fix #9036
This bug was introduced in src/main/frontend/modules/shortcut/config.cljs in PR #7786 because it placed :editor/undo and :editor/redo into global-prevent-default. It causes co...
fix: cannot undo redo in codemirror editor by situ2001 · Pull Reque...
Bader — Today at 14:31
@cldwalker I am working on connecting the undo and redo pages to their respective previous changelogs, enabling users to view all associated PRs and changes for this feature. This process will involve modifying some older changelog files; is that acceptable? Additionally, I noticed that the terms 'undo and redo,' 'undo/redo,' and 'undo && redo' are used interchangeably. Would you like me to standardize these as undo and redo, or should I add the various aliases to the page instead?
https://github.com/logseq/docs/compare/master...Bad3r:logseq-docs:add-undo-redo?expand=1

note; when I did find and replace my formatter removed trailing spaces from the files
Bader — Today at 14:52
since changing the undo and redo require accessing the command palette; this might be a good place to ask if the command palette will have its own page?
I found this todo in the docs:
TODO Resolve confusion between [[Commands]], [[Macros]], [[Advanced commands]] and commands in command palette #docs
```

related PRs:
- https://github.com/logseq/logseq/pull/9048
- https://github.com/logseq/logseq/pull/8228