### PR TITLE
Fix config key for journal date format

### DIFF
--- a/pages/setting___preferred journal format.md
+++ b/pages/setting___preferred journal format.md
@@ -1,9 +1,9 @@
-- You can set your preferred daily journal date format via `Settings` page
+- You can set your preferred daily journal date format via `Settings > Editor` page
 - Alternatively, you can add it in [[config.edn]]
 	- {{embed ((60acdeb9-aa65-492b-8398-d4d65c1631c1))}}
 	- Add your favorite date-formatter to [[config.edn]]:
 	  #+BEGIN_SRC clojure
-	  :date-formatter "yyyy-MM-dd"
+	  :journal/page-title-format "yyyy-MM-dd"
 	  #+END_SRC
 	  Currently, logseq support:
 	  #+BEGIN_SRC clojure


### PR DESCRIPTION
This PR fixes the config key mentioned for setting the preferred Journal date format.

Code reference for the config key: https://github.com/logseq/logseq/blob/6a22870d498cdbfec00a0c65ae0ef1aa6f264428/deps/graph-parser/src/logseq/graph_parser/config.cljs#L70-L76

![image](https://github.com/logseq/docs/assets/11085079/96049209-2028-4120-9345-efc08da3b7bb)
