### PR TITLE
add info on CANCELLED etc, and minor wording changes

### DIFF
--- a/pages/Tasks.md
+++ b/pages/Tasks.md
@@ -22,6 +22,7 @@ platforms:: [[All Platforms]]
 				- (_this is how `CANCELLED` renders_)
 			- IN-PROGRESS the fun thing
 			- WAIT the slow thing
+	- Once the block has been created, if it shows an empty tick-box at the start of the block you can manually click on that box to get it to change to `DONE`, which can be rather satisfying to do.
 - ## Functionality
 	- ### Priorities
 		- Logseq comes with three optional, built-in priorities that can be set with commands (`/A`, `/B`, `/C`):

--- a/pages/Tasks.md
+++ b/pages/Tasks.md
@@ -9,7 +9,7 @@ platforms:: [[All Platforms]]
 	  + You can toggle between those two flavors in the settings page
 	- There are two ways to attach workflow markers to your task block:
 		- when editing the block, press `Ctrl/Cmd+enter` to cycle through the workflow markers
-		- type these command directly, eg "LATER" "NOW" "DONE" "TODO" etc.
+		- type these commands directly (eg `/LATER`) anywhere in the block, or manually write the keyword at the start of the block (eg `LATER do grocery`)
 		- Some examples:
 		  todo:: 1621908710666
 			- LATER do grocery

--- a/pages/Tasks.md
+++ b/pages/Tasks.md
@@ -3,18 +3,25 @@ alias:: Todos
 platforms:: [[All Platforms]]
 
 - ## Usage
-	- Logseq comes with two built-in flavors to mark your block with built-in workflow mark keywords and manage your tasks:
+	- Logseq comes with two built-in flavors to mark your block with built-in workflow marker keywords and manage your tasks:
 	  + `LATER` -> `NOW` -> `DONE` flavor (default)
 	  + `TODO` -> `DOING` -> `DONE` flavor 
-	  + You can toggle between those two flavors in setting page
-	- There are two ways to attach workflow mark to your task(block)
-		- when editing the block, press `Ctrl/Cmd+enter` to cycle through the workflow mark
-		- type these mark as command directly, eg `/LATER` `/NOW` `/DONE` `/TODO` etc..
+	  + You can toggle between those two flavors in the settings page
+	- There are two ways to attach workflow markers to your task block:
+		- when editing the block, press `Ctrl/Cmd+enter` to cycle through the workflow markers
+		- type these command directly, eg "LATER" "NOW" "DONE" "TODO" etc.
 		- Some examples:
 		  todo:: 1621908710666
 			- LATER do grocery
 			- NOW play with Logseq
 			- DONE watch Doctor Who
+				- (_this is how `DONE` renders_)
+	- In addition to the workflows described above, there's also `CANCELED`/`CANCELLED`, `IN-PROGRESS`,  and `WAIT`/`WAITING` markers which can be typed directly.
+		- Some examples:
+			- CANCELLED the boring thing
+				- (_this is how `CANCELLED` renders_)
+			- IN-PROGRESS the fun thing
+			- WAIT the slow thing
 - ## Functionality
 	- ### Priorities
 		- Logseq comes with three optional, built-in priorities that can be set with commands (`/A`, `/B`, `/C`):
@@ -28,8 +35,9 @@ platforms:: [[All Platforms]]
 			  name:: C
 			  description:: Lowest priority
 			- Example:
-				- LATER [#A] research balalah is a top priority
-				- LATER [#C] do grocery has lowest priority
+				- LATER [#A] big important and urgent thing
+				- LATER [#C] the lower priority thing
+			- Again, these can either be added by using the commands (typing `/A`), or manually added by writing `[#A]` at the start of the block after the marker.
 	- ### Deadline and Scheduled
 		- There are two commands for setting dates on a block:
 			- type:: [[Command]]
@@ -42,7 +50,7 @@ platforms:: [[All Platforms]]
 			  description:: Type command `/Scheduled` to setup a scheduled date for a block
 				- eg: send John a birthday card Monday
 				  SCHEDULED: <2021-05-31 Mon>
-		- Both of the above commands work on blocks, not just tasks.
+		- Both of the above commands work on regular blocks too, not just tasks.
 		- Both of the above commands default to displaying blocks that are coming up soon. You can configure how soon with `:scheduled/future-days`  in [[config.edn]].
 		- Both of above commands support to mark the task as repeated:
 		  after typing the command and click `Add repeater` in the date picker


### PR DESCRIPTION
_First time PRing to this repo - let me know if there's any norms/rules I'm missing_

Following discussion [here](https://discuss.logseq.com/t/is-there-a-state-like-todo-which-represents-things-which-youve-decided-to-not-do-like-notdoingtodo/19788/5?u=da5nsy) I'd like to add some info on the task marker `CANCELLED`.