### PR TITLE
Edited macro usage section for clarity. 

### DIFF
--- a/pages/Macros.md
+++ b/pages/Macros.md
@@ -5,13 +5,12 @@ description:: Provides a way to write and maintain reusable text. This text can 
 - ## Usage
 	- ### Creating a macro
 		- Open the [[config.edn]] file.
-		- Scroll down to the `:macros` section. Each macro should be enclosed in curly brackets, with two strings enclosed in quotations.
-		- The first string `"foo"` is the macro name. The second string `"Hello $1"` is the text template.
+		- Scroll down to the `:macros` section. Add your macro's name in quotation marks `"foo"`, followed by its text template `"Hello $1"`, also in quotation marks. Separate them with a space.
 		- Variables such as `$1` and `$2` can be used to place parameters in the template.
 		- ```edn
 		  :macros {
-		  {"foo" "Hello $1"}
-		  {"bar" "Goodbye $1"}
+		  "foo" "Hello $1"
+		  "bar" "Goodbye $1"
 		  }
 		  ```
 		- For readability, use a line break to separate each macro

--- a/pages/Macros.md
+++ b/pages/Macros.md
@@ -5,10 +5,13 @@ description:: Provides a way to write and maintain reusable text. This text can 
 - ## Usage
 	- ### Creating a macro
 		- Open the [[config.edn]] file.
-		- Scroll down to the `:macros` section. Inside the curly brackets, add your macro's name in curly brackets followed by the text template, e.g.:
+		- Scroll down to the `:macros` section. Each macro should be enclosed in curly brackets, with two strings enclosed in quotations.
+		- The first string `"foo"` is the macro name. The second string `"Hello $1"` is the text template.
+		- Variables such as `$1` and `$2` can be used to place parameters in the template.
 		- ```edn
 		  :macros {
-		  "foo" "Hello $1"
+		  {"foo" "Hello $1"}
+		  {"bar" "Goodbye $1"}
 		  }
 		  ```
 		- For readability, use a line break to separate each macro


### PR DESCRIPTION
Fixed a mistake in the description of how to add macros to `config.edn`, and added a second line to the config file example to demonstrate separation of macros with a new line. 