### PR TITLE
Document namespaces and mention that a page can have multiple aliases

### DIFF
--- a/pages/Aliases and external links.md
+++ b/pages/Aliases and external links.md
@@ -2,4 +2,7 @@
 	- `[This is the label or name of the link](https://thisistheurl.com)`
 - Apart from linking to pages outside of Logseq, you can also use the alias function to link to an internal page. This is handy for when you want to show a different label for an internal link. For example, `[I worked on projects]([[Projects]])` will make the entire "I worked on projects" sentence clickable and point it to the _Projects_ page.
 - Finally, for aliases that you use often it's best to add a page alias. For example, you might want the link `[[PKM]]` to point to the page `Personal Knowledge Management`. To do this, add the following in the **first block** of the page `Personal Knowledge Management`: `alias:: PKM`
+	- A page can have more than one alias, separated by tags.
+		- For example, `alias:: PKM, Knowledge Management`
+	- Aliases can include a [namespace]([[Namespaces]]) as well. For example, `alias:: Recipes/Pho`
 - Now, anytime you click a `[[PKM]]` link, you'll end up on the `Personal Knowledge Management` page.

--- a/pages/Namespaces.md
+++ b/pages/Namespaces.md
@@ -2,4 +2,25 @@ type:: [[Feature]]
 platforms:: [[All Platforms]] 
 description:: Used to group a set of related pages
 
-- TODO Document this feature. Close https://github.com/logseq/docs/issues/58 when done #docs
+-
+- Namespaces can be used to **avoid name conflicts** and **build hierarchical page relationships**.
+- A page can be placed in a namespace by putting the namespace and a slash in the page's title.
+	- For example, to put this page in the `Important Features` namespace, you would title it `Important Features/Namespaces`
+-
+- Namespaces can be stacked: `Important Features/Very Important Features/Namespaces`
+- Pages in a namespace are automatically backlinked to the namespace's page.
+	- In our above example where we name this page `Important Features/Namespaces`, the page would be automatically backlinked to `Important Features`, and show up in the linked references section at the bottom.
+	- In the above multilevel namespace example, `Namespaces` would be backlinked to `Very Important Features`, and `Very Important Features` would be backlinked to `Important Features`.
+-
+- ## Example: Hierarchical Relationships
+	- Suppose you have a `[[Recipes]]` page, but you have so many recipes that it's inconvenient to put them all on a single page.
+	- You might still want to index all of them on one page. While doing so manually is possible, if you create a new page and forget to link it, it could be hard to find later.
+	- Instead, putting them in the `Recipes` namespace will automatically backlink them to the `Recipes` page, so that you never lose them. Naming your pages like `Recipes/Pho` and `Recipes/Chicken Noodle Soup` will backlink both of these to `Recipes.`
+	- If you wish to further organize your notes, this backlinking occurs at every namespace level.
+		- Suppose you wanted to sort your recipes by category, and put pho and chicken noodle soup in the soup category.
+		- You could title them `Recipes/Soup/Pho` and `Recipes/Soup/Chicken Noodle Soup`. Then, `Pho` and `Chicken Noodle Soup` would be backlinked to `Soup`, and `Soup` would be backlinked to `Recipes`.
+-
+- ## Example: Avoiding Name Conflicts
+	- Logseq will not let you name two pages the exact same thing.
+	- If you want two pages with the same name, they must be in different namespaces to prevent a conflict.
+	- For example, suppose you want to keep separate notes on airbrushing for model painting and airbrushing for baking. You could name them `Model Painting/Airbrushing` and `Baking/Airbrushing` to make them distinguishable.


### PR DESCRIPTION
I wrote the documentation for namespaces, including two examples. I also added to the namespaces page, and mentioned that a page can have more than one alias. 